### PR TITLE
sync with ROSA 2019.1: fix for differences in lower and upper case of P and R

### DIFF
--- a/cmake.prov
+++ b/cmake.prov
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # -*- coding:utf-8 -*-
 #
 # Copyright (C) 2015 Daniel Vrátil <dvratil@redhat.com>
@@ -28,7 +28,7 @@ import re
 
 class CMakeParser:
     def __init__(self, filelist=None):
-        if filelist is None:
+        if filelist == None:
             filelist = sys.stdin
 
         paths = map(lambda x: x.rstrip(), filelist.readlines())
@@ -38,9 +38,16 @@ class CMakeParser:
                 version = self.resolveCMakeModuleVersion(modulePath, cmakeModule, lowercase)
 
                 if version:
-                    print("cmake(%s) = %s" % (cmakeModule, version))
+                    string = "cmake(" + cmakeModule + ") = " + version
                 else:
-                    print("cmake(%s)" % cmakeModule)
+                    string = "cmake(" + cmakeModule + ")"
+                if string == string.lower():
+                    print(string)
+                else:
+                    # Temporarily print both variants to satisfy requires
+                    # by the old version of this generator which made mistakes
+                    print(string)
+                    print(string.lower())
 
     def parseCmakeModuleConfig(self, configFile):
         paths = configFile.rsplit("/", 3)

--- a/cmake.req
+++ b/cmake.req
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # -*- coding:utf-8 -*-
 #
 # Copyright (C) 2017 Björn Esser <besser82@fedoraproject.org>
@@ -55,7 +55,12 @@ class CMakeParser:
                                 # We could also check for the required version here, but
                                 # since cmake.prov creates unversioned Provides: lines,
                                 # that would be harmful
-                                print("cmake(%s)" % line.split("(")[1].split(")")[0].split(" ")[0])
+                                string = "cmake(" + line.split("(")[1].split(")")[0].split(" ")[0] + ")"
+                                # Remove printing original string later and sync with cmake.prov
+                                if string == string.lower():
+                                    print(string.lower())
+                                else:
+                                    print("(" + string.lower() + " or " + string + ")")
                 finally:
                     pass
 


### PR DESCRIPTION
Convert everything to lowercase in cmake.prov and cmake.req to workaround differences like this:

```
user@pay2:/mnt/dev/rosa-pkgs/cmake$ ls /tmp/*.cmake -1v
/tmp/cmake/qt5xdgiconloader-config.cmake
/tmp/cmake/qt5xdgiconloader-config-version.cmake
/tmp/cmake/qt5xdgiconloader-targets.cmake
/tmp/cmake/qt5xdgiconloader-targets-release.cmake

user@pay2:/mnt/dev/rosa-pkgs/cmake$ ls /tmp/lib64Qt5Xdg-devel-3.3.0-2-rosa2019.1.x86_64/usr/share/cmake/qt5xdg/*.cmake -1v | python3 cmake.req
cmake(Qt5Widgets)
cmake(Qt5Xml)
cmake(Qt5DBus)
cmake(Qt5XdgIconLoader)
cmake-filesystem

$ ls /tmp/cmake/*.cmake -1v | python3 cmake.prov
cmake(qt5xdgiconloader)
```

**cmake(qt5xdgiconloader) != cmake(Qt5XdgIconLoader)**

New sample output:
```
user@pay2:/mnt/dev/rosa-pkgs/cmake$ ls /tmp/lib64Qt5Xdg-devel-3.3.0-2-rosa2019.1.x86_64/usr/share/cmake/qt5xdg/*.cmake -1v | python3 cmake.req
(cmake(qt5widgets) or cmake(Qt5Widgets))
(cmake(qt5xml) or cmake(Qt5Xml))
(cmake(qt5dbus) or cmake(Qt5DBus))
(cmake(qt5xdgiconloader) or cmake(Qt5XdgIconLoader))
cmake-filesystem
```

Boolean dependencies "Requires: (cmake(foo) or cmake(Foo)" is a temporary solution to avoid rebuilding all cmake packages (rebootstrapping with this generator).

In some packages, e.g.
https://github.com/OpenMandrivaAssociation/libqtxdg/blob/master/libqtxdg.spec#L10
workarounds like `%global __requires_exclude ^cmake.*XdgIconLoader.*$` should be removed.